### PR TITLE
Fix lines width #1

### DIFF
--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -26,7 +26,7 @@ impl Drawing {
     }
 
     pub fn elements(&self) -> &Vec<Element> {
-        &self.elements 
+        &self.elements
     }
 
     pub fn from_svg(svg: &str) -> Result<Drawing> {
@@ -49,8 +49,9 @@ impl Drawing {
             sy = 1.0/cv.len();
             dy = -cv.cy();
         }
-        self.canvas_transform.scale(sx, sy);
         self.canvas_transform.translate(dx, dy);
+        // SVG has y axis directed downwards. We need to turn it upwards
+        self.canvas_transform.scale(sx, -sy);
 
         dbg!(&elements);
         for (_, element) in elements {
@@ -65,11 +66,10 @@ impl Drawing {
     }
 
     pub fn add_line(&mut self, x0: f64, y0: f64, x1: f64, y1: f64, width: f64) {
-        let mut p0 = Point { x: x0, y: y0 };
-        self.canvas_transform.transform(&mut p0);
-        let mut p1 = Point { x: x1, y: y1 };
-        self.canvas_transform.transform(&mut p1);
-        let line = Line { p: (p0, p1), width };
+        let p0 = Point { x: x0, y: y0 };
+        let p1 = Point { x: x1, y: y1 };
+        let mut line = Line { p: (p0, p1), width };
+        line.transform(&self.canvas_transform);
         self.elements.push(Element::Line(line));
     }
 
@@ -84,5 +84,5 @@ impl Drawing {
 
 // Private methods
 impl Drawing {
-    
+
 }

--- a/src/generators/kicad.rs
+++ b/src/generators/kicad.rs
@@ -59,8 +59,9 @@ impl KicadGenerator {
                     Element::Line(l) => {
                         let mut l = l.clone();
                         l.scale(grid, grid);
+                        const PART_NUMBER: u8 = 0; // TODO: Replace by attribute
                         write!(f, "P 2 {} 1 {} {} {} {} {} N\n",
-                            i,
+                            PART_NUMBER,
                             l.width.round(),
                             l.p.0.x.round(), l.p.0.y.round(),
                             l.p.1.x.round(), l.p.1.y.round()

--- a/src/generators/kicad.rs
+++ b/src/generators/kicad.rs
@@ -44,7 +44,7 @@ impl KicadGenerator {
             write!(f, "#\n# {}\n#\n", component.name())?;
             let symbol = component.symbol();
             write!(f, "DEF {} {} 0 {} {} {} {} L {}\n",
-                component.name(), 
+                component.name(),
                 symbol.attr("ref_des", "U"),
                 5, // Space. TODO: Replace by attribute
                 symbol.attr("show_pin_numbers", "N"),
@@ -57,11 +57,11 @@ impl KicadGenerator {
             for (i, element) in elements.iter().enumerate() {
                 match element {
                     Element::Line(l) => {
-                        let mut l = l.clone(); 
+                        let mut l = l.clone();
                         l.scale(grid, grid);
                         write!(f, "P 2 {} 1 {} {} {} {} {} N\n",
                             i,
-                            (l.width*grid).round(),
+                            l.width.round(),
                             l.p.0.x.round(), l.p.0.y.round(),
                             l.p.1.x.round(), l.p.1.y.round()
                         )?;

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -14,6 +14,12 @@ pub struct Point {
     pub y: f64,
 }
 
+impl Point {
+    pub fn distance(begin: &Point, end: &Point) -> f64 {
+        ((end.x - begin.x).powi(2) + (end.y - begin.y).powi(2)).sqrt()
+    }
+}
+
 impl Transform for Point {
     fn transform(&mut self, t: &Transformation) {
         t.transform(self);
@@ -26,8 +32,26 @@ pub struct Line {
     pub width: f64
 }
 
+impl Line {
+    pub fn length(&self) -> f64 {
+        Point::distance(&self.p.0, &self.p.1)
+    }
+}
+
 impl Transform for Line {
     fn transform(&mut self, t: &Transformation) {
+        let len = self.length();
+        if len > 0. {
+            let mut zero_point = Point { x: 0., y: 0. };
+            let mut width_perpendicular = Point {
+                x: self.width * (self.p.1.y - self.p.0.y) / len,
+                y: self.width * (self.p.1.x - self.p.0.x) / len,
+            };
+            zero_point.transform(t);
+            width_perpendicular.transform(t);
+            self.width = Point::distance(&zero_point, &width_perpendicular);
+        }
+
         self.p.0.transform(t);
         self.p.1.transform(t);
     }
@@ -75,15 +99,15 @@ impl Transformation {
     }
 
     fn multiply(&mut self, n: &[f64; 9]) {
-        let m00 = self.m[0]*n[0] + self.m[1]*n[3] + self.m[2]*n[6];
-        let m01 = self.m[0]*n[1] + self.m[1]*n[4] + self.m[2]*n[7];
-        let m02 = self.m[0]*n[2] + self.m[1]*n[5] + self.m[2]*n[8];
-        let m10 = self.m[3]*n[0] + self.m[4]*n[3] + self.m[5]*n[6];
-        let m11 = self.m[3]*n[1] + self.m[4]*n[4] + self.m[5]*n[7];
-        let m12 = self.m[3]*n[2] + self.m[4]*n[5] + self.m[5]*n[8];
-        let m20 = self.m[6]*n[0] + self.m[7]*n[3] + self.m[8]*n[6];
-        let m21 = self.m[6]*n[1] + self.m[7]*n[4] + self.m[8]*n[7];
-        let m22 = self.m[6]*n[2] + self.m[7]*n[5] + self.m[8]*n[8];
+        let m00 = n[0]*self.m[0] + n[1]*self.m[3] + n[2]*self.m[6];
+        let m01 = n[0]*self.m[1] + n[1]*self.m[4] + n[2]*self.m[7];
+        let m02 = n[0]*self.m[2] + n[1]*self.m[5] + n[2]*self.m[8];
+        let m10 = n[3]*self.m[0] + n[4]*self.m[3] + n[5]*self.m[6];
+        let m11 = n[3]*self.m[1] + n[4]*self.m[4] + n[5]*self.m[7];
+        let m12 = n[3]*self.m[2] + n[4]*self.m[5] + n[5]*self.m[8];
+        let m20 = n[6]*self.m[0] + n[7]*self.m[3] + n[8]*self.m[6];
+        let m21 = n[6]*self.m[1] + n[7]*self.m[4] + n[8]*self.m[7];
+        let m22 = n[6]*self.m[2] + n[7]*self.m[5] + n[8]*self.m[8];
         self.m = [
             m00, m01, m02,
             m10, m11, m12,

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -126,6 +126,13 @@ impl Svg {
         Ok(())
     }
 
+    fn length_to_coordinate(length: &Length) -> f64 {
+        match length.unit {
+            LengthUnit::None => length.num,
+            _ => panic!("Unexpected length unit: {:?}", length.unit),
+        }
+    }
+
     fn to_polygon(&mut self, attributes: &Attributes) -> Result<SvgPolygon> {
         let mut polygon = SvgPolygon::default();
         for attr in attributes.iter() {
@@ -164,14 +171,14 @@ impl Svg {
                                         self.current_y = y;
                                         polygon.p.push(SvgPoint { x, y, marker: false });
                                     },
-                                    _ => (),  
+                                    _ => (),
                                 }
                             }
                         }
                     },
                     AttributeId::StrokeWidth => {
                         if let AttributeValue::Length(ref width) = attr.value {
-                            polygon.width = width.num;
+                            polygon.width = Svg::length_to_coordinate(&width);
                         }
                     },
                     _ => (),


### PR DESCRIPTION
Fix lines width for issue #1 

Additional small changes:
- Fixed transformation matrix multiplication order. Seems like later transformations should be to the left from the earlier:
A * x = (A<sub>n</sub> * ... * A<sub>2</sub> * A<sub>1</sub>) * x = A<sub>n</sub> * (... * (A<sub>2</sub> * (A<sub>1</sub> * x))), where _x_ is a column vector and _A<sub>i</sub>_ is a matrix of i-th transformation.
- Invert y axis. If you add some non-symmetrical element to the drawing, you will see that in previous version it was rendered upside down.
- According to KiCad files format specification, polygon's second parameter is a _unit_ (or a _number of part_). And it should be 0 if the polygon is common to all element's parts. Seems like in our case it should always be zero (at least for now). That's why capacitor's pins lines (horizontal ones) received indices 2 and 3 for units B and C, and were not rendered at all.