### PR TITLE
Add text fields to element (#2)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -88,11 +88,12 @@ impl Config {
     pub fn get_f64(&self, key: &str)-> Result<f64> {
         let value = self.get_element(key)?;
         Ok(value.as_f64()
-            .unwrap_or(
+            .or(
                 value.as_i64()
-                .ok_or(ErrorKind::InvalidElementType(key.to_string(), "float".to_string()))?
-                as f64
-            ))
+                .and_then(|v| Some(v as f64))
+            )
+            .ok_or(ErrorKind::InvalidElementType(key.to_string(), "float".to_string()))?
+        )
     }
 
     pub fn insert_vec_if_missing(&mut self, key: &str) {

--- a/src/generators/kicad.rs
+++ b/src/generators/kicad.rs
@@ -3,10 +3,13 @@ use std::fs::File;
 use std::io::prelude::*;
 
 use crate::errors::*;
+use crate::config::Config;
 use crate::library::Library;
+use crate::component::Component;
 use crate::generators::GeneratorHandler;
 use crate::geometry::Transform;
-use crate::drawing::Element;
+use crate::drawing::{Element, Drawing};
+use crate::text::*;
 
 const KICADLIB_DIR: &str = "kicadlib";
 
@@ -33,48 +36,198 @@ impl GeneratorHandler for KicadGenerator {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
+enum FieldKind {
+    Reference = 0,
+    Value = 1,
+}
+
+struct FontSize {
+    pub default: f64,
+    pub ref_des: f64,
+    pub name: f64,
+    pub pin: f64,
+}
+
+impl FontSize {
+    pub fn new(config: &Config) -> Result<FontSize> {
+        Ok(FontSize {
+            default: config.get_f64("generator.font_size.default")?,
+            ref_des: config.get_f64("generator.font_size.ref_des")?,
+            name: config.get_f64("generator.font_size.name")?,
+            pin: config.get_f64("generator.font_size.pin")?,
+        })
+    }
+
+    pub fn size(&self, kind: FieldKind) -> f64 {
+        match kind {
+            FieldKind::Reference => self.ref_des,
+            FieldKind::Value => self.name,
+        }
+    }
+}
+
+struct GeneratorParameters {
+    grid: f64,
+    font_size: FontSize,
+}
+
+impl GeneratorParameters {
+    pub fn new(config: &Config) -> Result<GeneratorParameters> {
+        Ok(GeneratorParameters {
+            grid: config.get_f64("generator.symbol_grid")?,
+            font_size: FontSize::new(&config)?,
+        })
+    }
+}
+
+trait ToLetter {
+    fn to_letter(&self) -> char;
+}
+
+impl ToLetter for Orientation {
+    fn to_letter(&self) -> char {
+        match self {
+            Orientation::Horizontal => 'H',
+            Orientation::Vertical => 'V',
+        }
+    }
+}
+
+impl ToLetter for HorizontalAlignment {
+    fn to_letter(&self) -> char {
+        match self {
+            HorizontalAlignment::Left => 'L',
+            HorizontalAlignment::Center => 'C',
+            HorizontalAlignment::Right => 'R',
+        }
+    }
+}
+
+impl ToLetter for VerticalAlignment {
+    fn to_letter(&self) -> char {
+        match self {
+            VerticalAlignment::Top => 'T',
+            VerticalAlignment::Center => 'C',
+            VerticalAlignment::Bottom => 'B',
+        }
+    }
+}
+
+impl ToLetter for Visibility {
+    fn to_letter(&self) -> char {
+        match self {
+            Visibility::Visible => 'V',
+            Visibility::Hidden => 'H',
+        }
+    }
+}
+
 impl KicadGenerator {
     fn render_symbols(&self, name: &str, library: &Library) -> Result<()> {
-        let grid = library.config().get_f64("generator.symbol_grid")?;
+        let params = GeneratorParameters::new(&library.config())?;
         let mut f = File::create(format!("{}/{}.lib", KICADLIB_DIR, name))?;
+
         f.write(b"EESchema-LIBRARY Version 2.4\n")?;
         f.write(b"#encoding utf-8\n")?;
+
         let components = library.components();
         for component in components {
-            write!(f, "#\n# {}\n#\n", component.name())?;
             let symbol = component.symbol();
-            write!(f, "DEF {} {} 0 {} {} {} {} L {}\n",
-                component.name(),
-                symbol.attr("ref_des", "U"),
-                5, // Space. TODO: Replace by attribute
-                symbol.attr("show_pin_numbers", "N"),
-                symbol.attr("show_pin_names", "N"),
-                1, // Symbols count. TODO: Replace by attribute
-                symbol.attr("power", "N"),
-            )?;
-            let elements = symbol.elements();
+            KicadGenerator::write_component_header(&mut f, &params, &component, &symbol)?;
+
             f.write(b"DRAW\n")?;
-            for (_i, element) in elements.iter().enumerate() {
-                match element {
-                    Element::Line(l) => {
-                        let mut l = l.clone();
-                        l.scale(grid, grid);
-                        const PART_NUMBER: u8 = 0; // TODO: Replace by attribute
-                        write!(f, "P 2 {} 1 {} {} {} {} {} N\n",
-                            PART_NUMBER,
-                            l.width.round(),
-                            l.p.0.x.round(), l.p.0.y.round(),
-                            l.p.1.x.round(), l.p.1.y.round()
-                        )?;
-                        println!("Line: {}, {}, {}, {}", l.p.0.x, l.p.0.y, l.p.1.x, l.p.1.y);
-                    },
-                    //_ => (),
-                }
+            let elements = symbol.elements();
+            for element in elements.iter() {
+                KicadGenerator::write_element(&mut f, &params, &element)?;
             }
             f.write(b"ENDDRAW\n")?;
             f.write(b"ENDDEF\n")?;
         }
+
         f.write(b"#\n#End Library\n")?;
+        Ok(())
+    }
+
+    fn write_element(mut f: &File, params: &GeneratorParameters, element: &Element) -> Result<()> {
+        match element {
+            Element::Line(l) => {
+                let mut l = l.clone();
+                l.scale(params.grid, params.grid);
+                write!(
+                    f,
+                    "P {points_number} {unit} {convert} {thickness} {x1} {y1} {x2} {y2} N\n",
+                    points_number = 2,
+                    unit = 0, // 0 if common to the parts; if not, number of part
+                        // TODO: Replace "unit" by attribute
+                    convert = 1, // 0 if common to the 2 representations, if not 1 or 2
+                    thickness = l.width.round(),
+                    x1 = l.p.0.x.round(), y1 = l.p.0.y.round(),
+                    x2 = l.p.1.x.round(), y2 = l.p.1.y.round(),
+                )?;
+                println!("Line: {}, {}, {}, {}", l.p.0.x, l.p.0.y, l.p.1.x, l.p.1.y);
+            },
+        }
+        Ok(())
+    }
+
+    fn write_component_header(
+        mut f: &File,
+        params: &GeneratorParameters,
+        component: &Component,
+        symbol: &Drawing,
+    ) -> Result<()> {
+        write!(f, "#\n# {}\n#\n", component.name())?;
+        let ref_des = symbol.attr("ref_des", "U");
+        write!(
+            f,
+            "DEF {name} {reference} {unused} {text_offset} {draw_pinnumber} {draw_pinname} \
+             {unit_count} {units_locked} {option_flag}\n",
+            name = component.name(),
+            reference = ref_des,
+            unused = 0, // Required by specification to be zero
+            text_offset = 5, // Space. TODO: Replace by attribute
+            draw_pinnumber = symbol.attr("show_pin_numbers", "N"),
+            draw_pinname = symbol.attr("show_pin_names", "N"),
+            unit_count = 1, // Symbols count. TODO: Replace by attribute
+            units_locked = "L",
+            option_flag = symbol.attr("power", "N"),
+        )?;
+
+        if let Some(refdes_textbox) = &symbol.refdes() {
+            KicadGenerator::write_field(
+                &mut f, &params, FieldKind::Reference, &ref_des, refdes_textbox
+            )?;
+        }
+        if let Some(value_textbox) = &symbol.value() {
+            KicadGenerator::write_field(
+                &mut f, &params, FieldKind::Value, component.name(), value_textbox
+            )?;
+        }
+        Ok(())
+    }
+
+    fn write_field(
+        mut f: &File,
+        params: &GeneratorParameters,
+        kind: FieldKind,
+        text: &str,
+        text_box: &TextBox,
+    ) -> Result<()> {
+        write!(
+            f,
+            "F{field_number} \"{text}\" {x} {y} {dimension} {orientation} {visibility} {hjustify} \
+             {vjustify}NN\n",
+            field_number = kind as u8,
+            text = text,
+            x = (text_box.x * params.grid).round(),
+            y = (text_box.y * params.grid).round(),
+            dimension = (params.font_size.size(kind) * params.grid).round(),
+            orientation = text_box.orientation.to_letter(),
+            visibility = text_box.visibility.to_letter(),
+            hjustify = text_box.halign.to_letter(),
+            vjustify = text_box.valign.to_letter(),
+        )?;
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod patterns;
 mod geometry;
 mod generators;
 mod svg;
+mod text;
 
 pub use errors::Result;
 

--- a/src/qeda.yml
+++ b/src/qeda.yml
@@ -4,3 +4,8 @@ timeout_secs: 5
 generator:
   type: kicad
   symbol_grid: 50
+  font_size:
+    default: 0.5
+    ref_des: 0.5
+    name: 0.5
+    pin: 0.5

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,0 +1,91 @@
+use crate::svg::SvgRect;
+
+#[derive(Debug)]
+pub enum Orientation {
+    Horizontal,
+    Vertical,
+}
+
+impl Default for Orientation {
+    fn default() -> Self { Orientation::Horizontal }
+}
+
+#[derive(Debug)]
+pub enum HorizontalAlignment {
+    Left,
+    Center,
+    Right,
+}
+
+impl HorizontalAlignment {
+    pub fn from_attr(attr: Option<&&str>) -> HorizontalAlignment {
+        match attr {
+            Some(&"left") => HorizontalAlignment::Left,
+            Some(&"right") => HorizontalAlignment::Right,
+            Some(&"center") => HorizontalAlignment::Center,
+            _ => HorizontalAlignment::default(),
+        }
+    }
+
+    pub fn calc_anchor_x(&self, rect: &SvgRect) -> f64 {
+        match self {
+            HorizontalAlignment::Left => rect.x,
+            HorizontalAlignment::Center => rect.x + rect.width / 2.,
+            HorizontalAlignment::Right => rect.x + rect.width,
+        }
+    }
+}
+
+impl Default for HorizontalAlignment {
+    fn default() -> Self { HorizontalAlignment::Left }
+}
+
+#[derive(Debug)]
+pub enum VerticalAlignment {
+    Top,
+    Center,
+    Bottom,
+}
+
+impl VerticalAlignment {
+    pub fn from_attr(attr: Option<&&str>) -> VerticalAlignment {
+        match attr {
+            Some(&"bottom") => VerticalAlignment::Bottom,
+            Some(&"top") => VerticalAlignment::Top,
+            Some(&"center") => VerticalAlignment::Center,
+            _ => VerticalAlignment::default(),
+        }
+    }
+
+    pub fn calc_anchor_y(&self, rect: &SvgRect) -> f64 {
+        match self {
+            VerticalAlignment::Top => rect.y,
+            VerticalAlignment::Center => rect.y + rect.height / 2.,
+            VerticalAlignment::Bottom => rect.y + rect.height,
+        }
+    }
+}
+
+impl Default for VerticalAlignment {
+    fn default() -> Self { VerticalAlignment::Center }
+}
+
+#[derive(Debug)]
+pub enum Visibility {
+    Visible,
+    Hidden,
+}
+
+impl Default for Visibility {
+    fn default() -> Self { Visibility::Visible }
+}
+
+#[derive(Default, Debug)]
+pub struct TextBox {
+    pub x: f64,
+    pub y: f64,
+    pub orientation: Orientation,
+    pub visibility: Visibility,
+    pub halign: HorizontalAlignment,
+    pub valign: VerticalAlignment,
+}

--- a/src/text.rs
+++ b/src/text.rs
@@ -88,4 +88,5 @@ pub struct TextBox {
     pub visibility: Visibility,
     pub halign: HorizontalAlignment,
     pub valign: VerticalAlignment,
+    pub id: String,
 }


### PR DESCRIPTION
Add refdes and value text fields for issue #2

Several helper text-related enums were added to text.rs file.
Font size is taken from qeda.yml file, though I'm not sure in which units it should be specified. Currently it's simply multiplied by the grid setting.

Also fixed was a small bug in config.rs which caused _panic_ if the value wasn't an integer.