### PR TITLE
Generate pins from SVG (#5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,14 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +649,7 @@ dependencies = [
  "error-chain 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "svgdom 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -695,6 +704,22 @@ dependencies = [
 [[package]]
 name = "redox_syscall"
 version = "0.1.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex"
+version = "1.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -932,6 +957,14 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1216,6 +1249,7 @@ dependencies = [
 [metadata]
 "checksum addr2line 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
 "checksum adler32 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
+"checksum aho-corasick 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)" = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
@@ -1299,6 +1333,8 @@ dependencies = [
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+"checksum regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+"checksum regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)" = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 "checksum remove_dir_all 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 "checksum reqwest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
 "checksum roxmltree 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "330d8f80a274bc3cb608908ee345970e7e24b96907f1ad69615a498bec57871c"
@@ -1325,6 +1361,7 @@ dependencies = [
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 "checksum tinyvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
 "checksum tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ reqwest = { version = "0.10", features = ["blocking"] }
 svgdom = "0.18"
 termcolor = "1.1"
 yaml-rust = "0.4"
+regex = "1.3"

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use regex::Regex;
 
 use crate::errors::*;
 use crate::geometry::*;
@@ -133,20 +134,13 @@ impl Drawing {
 
     fn add_pin(&mut self, key: &String, x0: f64, y0: f64, x1: f64, y1: f64) {
         let id_attrs: Vec<&str> = key.split(':').collect();
-        let net = *id_attrs.get(0).unwrap_or(&"");
-        let net = if net.starts_with("pin") {
-            &net[3..]
-        } else {
-            net
-        };
-        let net = if net.starts_with("-") {
-            &net[1..]
-        } else {
-            net
-        };
 
-        let halign = HAlign::from_attr(id_attrs.get(1));
-        let valign = VAlign::from_attr(id_attrs.get(2));
+        let id = *id_attrs.get(SvgPinIdAttrs::Id as usize).unwrap_or(&"");
+        let net_regex = Regex::new(r"^(pin)?\-?(?P<net>.*)$").unwrap();
+        let net = net_regex.captures(id).unwrap().name("net").unwrap().as_str();
+
+        let halign = HAlign::from_attr(id_attrs.get(SvgPinIdAttrs::HAlign as usize));
+        let valign = VAlign::from_attr(id_attrs.get(SvgPinIdAttrs::VAlign as usize));
 
         let p0 = Point { x: x0, y: y0 };
         let p1 = Point { x: x1, y: y1 };

--- a/src/generators/kicad.rs
+++ b/src/generators/kicad.rs
@@ -82,15 +82,11 @@ impl GeneratorParameters {
     }
 }
 
-trait ToLetter {
-    fn to_letter(&self) -> char;
-}
-
-impl ToLetter for Orientation {
-    fn to_letter(&self) -> char {
+impl fmt::Display for Orientation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Orientation::Horizontal => 'H',
-            Orientation::Vertical => 'V',
+            Orientation::Horizontal => write!(f, "H"),
+            Orientation::Vertical => write!(f, "V"),
         }
     }
 }
@@ -124,53 +120,47 @@ impl fmt::Display for Visibility {
     }
 }
 
-impl ToLetter for ElectricKind {
-    fn to_letter(&self) -> char {
+impl fmt::Display for ElectricKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ElectricKind::Input => 'I',
-            ElectricKind::Output => 'O',
-            ElectricKind::Bidirectional => 'B',
-            ElectricKind::Tristate => 'T',
-            ElectricKind::Passive => 'P',
-            ElectricKind::Unspecified => 'U',
-            ElectricKind::PowerInput => 'W',
-            ElectricKind::PowerOutput => 'w',
-            ElectricKind::OpenCollector => 'C',
-            ElectricKind::OpenEmitter => 'E',
-            ElectricKind::NotConnected => 'N',
-        }
-    }
-}
-
-impl PinShape {
-    fn to_str(&self) -> &str {
-        match self {
-            PinShape::Line => "",
-            PinShape::Inverted => "I",
-            PinShape::Clock => "C",
-            PinShape::InvertedClock => "CI",
-            PinShape::InputLow => "L",
-            PinShape::ClockLow => "CL",
-            PinShape::OutputLow => "V",
-            PinShape::FallingEdgeClock => "F",
-            PinShape::NonLogic => "X",
+            ElectricKind::Input => write!(f, "I"),
+            ElectricKind::Output => write!(f, "O"),
+            ElectricKind::Bidirectional => write!(f, "B"),
+            ElectricKind::Tristate => write!(f, "T"),
+            ElectricKind::Passive => write!(f, "P"),
+            ElectricKind::Unspecified => write!(f, "U"),
+            ElectricKind::PowerInput => write!(f, "W"),
+            ElectricKind::PowerOutput => write!(f, "w"),
+            ElectricKind::OpenCollector => write!(f, "C"),
+            ElectricKind::OpenEmitter => write!(f, "E"),
+            ElectricKind::NotConnected => write!(f, "N"),
         }
     }
 }
 
 impl fmt::Display for PinShape {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_str())
+        match self {
+            PinShape::Line => write!(f, ""),
+            PinShape::Inverted => write!(f, "I"),
+            PinShape::Clock => write!(f, "C"),
+            PinShape::InvertedClock => write!(f, "CI"),
+            PinShape::InputLow => write!(f, "L"),
+            PinShape::ClockLow => write!(f, "CL"),
+            PinShape::OutputLow => write!(f, "V"),
+            PinShape::FallingEdgeClock => write!(f, "F"),
+            PinShape::NonLogic => write!(f, "X"),
+        }
     }
 }
 
-impl ToLetter for PinOrientation {
-    fn to_letter(&self) -> char {
+impl fmt::Display for PinOrientation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            PinOrientation::Up => 'U',
-            PinOrientation::Down => 'D',
-            PinOrientation::Right => 'R',
-            PinOrientation::Left => 'L',
+            PinOrientation::Up => write!(f, "U"),
+            PinOrientation::Down => write!(f, "D"),
+            PinOrientation::Right => write!(f, "R"),
+            PinOrientation::Left => write!(f, "L"),
         }
     }
 }
@@ -229,18 +219,22 @@ impl KicadGenerator {
                 write!(
                     f,
                     "X {name} {number} {posx} {posy} {length} {orientation} {snum} {snom} \
-                    {unit} {convert} {etype} {shape}\n",
+                    {unit} {convert} {etype} {visibility}{shape}\n",
                     name = pin.net,
                     number = pin.number,
                     posx = p.x.round(),
                     posy = p.y.round(),
                     length = (pin.length * params.grid).round(),
-                    orientation = pin.orientation.to_letter(),
+                    orientation = pin.orientation,
                     snum = params.font_size.pin, // pin number text size
                     snom = params.font_size.name, // pin name text size
                     unit = 0, // 0 if common to all parts. If not, number of the part (1. .n)
                     convert = 0, // 0 if common to the representations, if not 1 or 2
-                    etype = pin.ekind.to_letter(),
+                    etype = pin.ekind,
+                    visibility = match pin.visibility {
+                        Visibility::Visible => "",
+                        Visibility::Hidden => "N",
+                    },
                     shape = pin.shape,
                 )?;
                 debug!("Pin: {}, {}, ({}, {})", pin.net, pin.number, pin.pos.x, pin.pos.y);
@@ -317,7 +311,7 @@ impl KicadGenerator {
                 x = (text_box.x * params.grid).round(),
                 y = (text_box.y * params.grid).round(),
                 dimension = params.font_size.size(field_kind).round(),
-                orientation = text_box.orientation.to_letter(),
+                orientation = text_box.orientation,
                 visibility = text_box.visibility,
                 hjustify = text_box.halign,
                 vjustify = text_box.valign,

--- a/src/generators/kicad.rs
+++ b/src/generators/kicad.rs
@@ -148,7 +148,7 @@ impl PinShape {
             PinShape::Line => "",
             PinShape::Inverted => "I",
             PinShape::Clock => "C",
-            PinShape::InvertedClock => "CL",
+            PinShape::InvertedClock => "CI",
             PinShape::InputLow => "L",
             PinShape::ClockLow => "CL",
             PinShape::OutputLow => "V",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod symbols;
 mod patterns;
 mod geometry;
 mod generators;
+mod pin;
 mod svg;
 mod text;
 

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -45,10 +45,11 @@ pub struct Pin {
     pub pos: Point,
     pub length: f64,
     pub net: String,
-    pub number: u32,
+    pub number: String,
     pub ekind: ElectricKind,
     pub shape: PinShape,
     pub orientation: PinOrientation,
+    pub visibility: Visibility,
 }
 
 impl Pin {
@@ -80,10 +81,11 @@ impl Pin {
             pos: Point { x: posx, y: posy },
             length: l.length(),
             net: net.to_string(),
-            number: 0,
+            number: "0".to_string(),
             ekind: ElectricKind::Unspecified,
             shape: PinShape::Line,
             orientation: orientation,
+            visibility: Visibility::Visible,
         }
     }
 }

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,0 +1,89 @@
+use crate::geometry::*;
+use crate::text::*;
+
+#[allow(dead_code)]
+#[derive(Debug, Copy, Clone)]
+pub enum ElectricKind {
+    Input,
+    Output,
+    Bidirectional,
+    Tristate,
+    Passive,
+    Unspecified,
+    PowerInput,
+    PowerOutput,
+    OpenCollector,
+    OpenEmitter,
+    NotConnected,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Copy, Clone)]
+pub enum PinShape {
+    Line,
+    Inverted,
+    Clock,
+    InvertedClock,
+    InputLow,
+    ClockLow,
+    OutputLow,
+    FallingEdgeClock,
+    NonLogic,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Copy, Clone)]
+pub enum PinOrientation {
+    Up,
+    Down,
+    Right,
+    Left,
+}
+
+#[derive(Debug)]
+pub struct Pin {
+    pub pos: Point,
+    pub length: f64,
+    pub net: String,
+    pub number: u32,
+    pub ekind: ElectricKind,
+    pub shape: PinShape,
+    pub orientation: PinOrientation,
+}
+
+impl Pin {
+    pub fn new(net: &str, halign: HAlign, valign: VAlign, l: &Line) -> Self {
+        let orientation = match halign {
+            HAlign::Center => {
+                match valign {
+                    VAlign::Top => PinOrientation::Down,
+                    _ => PinOrientation::Up,
+                }
+            },
+            HAlign::Left => PinOrientation::Right,
+            HAlign::Right => PinOrientation::Left,
+        };
+
+        let posx = match orientation {
+            PinOrientation::Down | PinOrientation::Up => l.p.0.x,
+            PinOrientation::Right => l.p.0.x.min(l.p.1.x),
+            PinOrientation::Left => l.p.0.x.max(l.p.1.x),
+        };
+
+        let posy = match orientation {
+            PinOrientation::Down => l.p.0.y.max(l.p.1.y),
+            PinOrientation::Up => l.p.0.y.min(l.p.1.y),
+            PinOrientation::Right | PinOrientation::Left => l.p.0.y,
+        };
+
+        Pin {
+            pos: Point { x: posx, y: posy },
+            length: l.length(),
+            net: net.to_string(),
+            number: 0,
+            ekind: ElectricKind::Unspecified,
+            shape: PinShape::Line,
+            orientation: orientation,
+        }
+    }
+}

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -9,6 +9,12 @@ pub enum SvgRectIdAttrs {
     VAlign = 2,
 }
 
+pub enum SvgPinIdAttrs {
+    Id = 0,
+    HAlign = 1,
+    VAlign = 2,
+}
+
 #[derive(Debug)]
 pub enum SvgHAlign {
     Left,

--- a/src/symbols/capacitor.rs
+++ b/src/symbols/capacitor.rs
@@ -1,7 +1,8 @@
 use crate::errors::*;
 use crate::config::Config;
 use crate::symbols::SymbolHandler;
-use crate::drawing::{Drawing, Element};
+use crate::symbols::pinout::Pinout;
+use crate::drawing::Drawing;
 
 pub struct CapacitorSymbol {}
 
@@ -12,19 +13,17 @@ impl CapacitorSymbol {
 }
 
 impl SymbolHandler for CapacitorSymbol {
-    fn draw(&self, _config: &Config)-> Result<Drawing> {
+    fn draw(&self, config: &Config)-> Result<Drawing> {
         debug!("draw capacitor symbol");
+
         let mut drawing = Drawing::from_svg(include_str!("capacitor.svg"))?;
         drawing.add_attr("ref-des", "C");
-        for element in drawing.mut_elements() {
-            if let Element::Pin(pin) = element {
-                match pin.net.as_str() {
-                    "L" => pin.number = 1,
-                    "R" => pin.number = 2,
-                    _ => {},
-                }
-            }
-        }
+
+        let mut pinout = Pinout::from_config(config);
+        pinout.add_default("L", 1);
+        pinout.add_default("R", 2);
+        pinout.apply_to(drawing.mut_elements());
+
         Ok(drawing)
     }
 }

--- a/src/symbols/capacitor.rs
+++ b/src/symbols/capacitor.rs
@@ -1,7 +1,7 @@
 use crate::errors::*;
 use crate::config::Config;
 use crate::symbols::SymbolHandler;
-use crate::drawing::Drawing;
+use crate::drawing::{Drawing, Element};
 
 pub struct CapacitorSymbol {}
 
@@ -16,6 +16,15 @@ impl SymbolHandler for CapacitorSymbol {
         debug!("draw capacitor symbol");
         let mut drawing = Drawing::from_svg(include_str!("capacitor.svg"))?;
         drawing.add_attr("ref-des", "C");
+        for element in drawing.mut_elements() {
+            if let Element::Pin(pin) = element {
+                match pin.net.as_str() {
+                    "L" => pin.number = 1,
+                    "R" => pin.number = 2,
+                    _ => {},
+                }
+            }
+        }
         Ok(drawing)
     }
 }

--- a/src/symbols/capacitor.rs
+++ b/src/symbols/capacitor.rs
@@ -20,8 +20,8 @@ impl SymbolHandler for CapacitorSymbol {
         drawing.add_attr("ref-des", "C");
 
         let mut pinout = Pinout::from_config(config);
-        pinout.add_default("L", 1);
-        pinout.add_default("R", 2);
+        pinout.add_default("L", "1");
+        pinout.add_default("R", "2");
         pinout.apply_to(drawing.mut_elements());
 
         Ok(drawing)

--- a/src/symbols/capacitor.svg
+++ b/src/symbols/capacitor.svg
@@ -100,12 +100,12 @@
      style="opacity:1;fill:#0000ff;stroke:#000000;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-opacity:1" />
   <path
      inkscape:connector-curvature="0"
-     id="pin:left:middle"
+     id="pin-L:left:middle"
      d="M 5,10 H 9.25"
      style="fill:none;stroke:#0000ff;stroke-width:0.20002499;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#DotM)" />
   <path
      inkscape:connector-curvature="0"
-     id="pin:right:middle"
+     id="pin-R:right:middle"
      d="M 15,10 H 10.75"
      style="fill:none;stroke:#0000ff;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker1116)" />
   <rect

--- a/src/symbols/mod.rs
+++ b/src/symbols/mod.rs
@@ -1,4 +1,5 @@
 mod capacitor;
+mod pinout;
 
 use std::collections::HashMap;
 use std::fmt::{self, Debug};

--- a/src/symbols/pinout.rs
+++ b/src/symbols/pinout.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+
+use yaml_rust::Yaml;
+
+use crate::config::Config;
+use crate::drawing::Element;
+
+pub struct Pinout {
+    pins: HashMap<String, Vec<u32>>,
+}
+
+impl Pinout {
+    pub fn from_config(config: &Config) -> Self {
+        let mut pinout = Pinout {
+            pins: HashMap::new(),
+        };
+        if let Ok(config_pinout) = config.get_hash("pinout") {
+            for (pin, numbers) in config_pinout {
+                if let Yaml::String(pin) = pin {
+                    let numbers = match numbers {
+                        Yaml::Integer(number) => {
+                            vec!(*number as u32)
+                        },
+                        Yaml::Array(numbers) => {
+                            numbers.iter().filter_map(|number| match number {
+                                Yaml::Integer(number) => Some(*number as u32),
+                                _ => None,
+                            }).collect()
+                        },
+                        Yaml::String(numbers) => {
+                            numbers.split(',').filter_map(|number| match number.trim().parse() {
+                                Ok(number) => Some(number),
+                                _ => None,
+                            }).collect()
+                        },
+                        _ => vec!(),
+                    };
+                    pinout.pins.insert(pin.to_string(), numbers);
+                }
+            }
+        }
+        pinout
+    }
+
+    pub fn add_default(&mut self, pin: &str, number: u32) {
+        if self.pins.contains_key(pin) {
+            return
+        }
+        self.pins.insert(pin.to_string(), vec!(number));
+    }
+
+    pub fn apply_to(&self, elements: &mut Vec<Element>) {
+        let mut pin_counter = HashMap::new();
+        for element in elements {
+            if let Element::Pin(pin) = element {
+                if let Some(numbers) = self.pins.get(&pin.net) {
+                    let index = *pin_counter.get(&pin.net).unwrap_or(&(0 as usize));
+                    pin.number = *numbers.get(index).unwrap();
+                    pin_counter.insert(&pin.net, index + 1);
+                }
+            }
+        }
+    }
+}

--- a/src/symbols/pinout.rs
+++ b/src/symbols/pinout.rs
@@ -18,21 +18,16 @@ impl Pinout {
             for (pin, numbers) in config_pinout {
                 if let Yaml::String(pin) = pin {
                     let numbers = match numbers {
-                        Yaml::Integer(number) => {
-                            vec!(*number as u32)
-                        },
-                        Yaml::Array(numbers) => {
-                            numbers.iter().filter_map(|number| match number {
+                        Yaml::Integer(number) => vec!(*number as u32),
+                        Yaml::Array(numbers) => numbers.iter().filter_map(
+                            |number| match number {
                                 Yaml::Integer(number) => Some(*number as u32),
                                 _ => None,
-                            }).collect()
-                        },
-                        Yaml::String(numbers) => {
-                            numbers.split(',').filter_map(|number| match number.trim().parse() {
-                                Ok(number) => Some(number),
-                                _ => None,
-                            }).collect()
-                        },
+                            }
+                        ).collect(),
+                        Yaml::String(numbers) => numbers.split(',').filter_map(
+                            |number| number.trim().parse().ok()
+                        ).collect(),
                         _ => vec!(),
                     };
                     pinout.pins.insert(pin.to_string(), numbers);


### PR DESCRIPTION
Pin information (such as net and alignment) is taken from SVG and added to a symbol file.
In symbol configuration file (yaml) default net numbers can be reassigned using ``pinout`` section.

I don't yet understand how to use ``valign`` and ``halign`` with multiple horizontal/vertical pins in SVG file. So currently they are used only to specify pin direction.
As I understand, these parameters are more useful for elements generated from YAML config (e.g. various integrated circuits), not from SVG image (in which each pin is drawn separately and already has its coordinates specified).

Should we treat single pin drawn in SVG as multiple pins if there are several numbers for its net given in YAML config? In that case we probably may use original qeda settings for pin spacing, something like:
```yaml
space:
  pin: 2
```